### PR TITLE
Mount Current directory with write access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - 8888:8000
     volumes:
-      - .:/usr/src/app:ro
+      - .:/usr/src/app
     entrypoint: ../../apps_dev/dev-entrypoint.sh
     command: "python manage.py runserver 0.0.0.0:8000"
 


### PR DESCRIPTION
This is required for installation of files using the dev-entrypoint.sh
Without this, pip gives a "Read-Only File System" error.
@jlost and I discussed about this and if giving read write access doesn't disrupt the app as a whole, it's the best and cleanest way to go about the bug that was coming up.