### PR TITLE
Specific files for environment variables

### DIFF
--- a/.defaults.env
+++ b/.defaults.env
@@ -1,0 +1,7 @@
+# NetDash Defaults File
+# This file contains default settings for environment files.
+# To modify any of these variables, modify .user-settings.env file.
+NETDASH_DEBUG=True
+NETDASH_SECRET_KEY=12345
+NETDASH_DEVICE_MODULE=netdash_device_netbox_api
+DATABASE_URL=postgres://netdash@database/netdash

--- a/.defaults.env
+++ b/.defaults.env
@@ -5,3 +5,4 @@ NETDASH_DEBUG=True
 NETDASH_SECRET_KEY=12345
 NETDASH_DEVICE_MODULE=netdash_device_netbox_api
 DATABASE_URL=postgres://netdash@database/netdash
+NETDASH_MODULES=

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ db.sqlite3
 
 # Environments
 /venv/
+
+/apps_dev

--- a/.user-settings.env
+++ b/.user-settings.env
@@ -1,0 +1,3 @@
+# NetDash User Settings File
+# Override variables set in .defaults.env file here and add new variables in this file.
+# Format: VAR=VAL pairs with one in each line.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN pipenv install --system
 WORKDIR /usr/src/app/src/netdash
 
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+
+# TODO add CMD with gunicorn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7
 
 RUN pip install psycopg2-binary
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 EXPOSE 8000
 

--- a/apps_dev/README.md
+++ b/apps_dev/README.md
@@ -1,0 +1,5 @@
+This directory is ignored by git, with the exception of this README and the dev-entrypoint.sh script.
+
+When docker-compose us used with the included docker-compose.yml file, the dev-entrypoint.sh script will attempt to install any subdirectories in the `apps_dev` directory as Python packages in "editable" mode.
+
+To take advantage of this in your workflow to develop NetDash apps, clone your app into the `apps_dev` directory.

--- a/apps_dev/dev-entrypoint.sh
+++ b/apps_dev/dev-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo $(pwd)
+for app in $(ls -d ../../apps_dev/*/); do
+    pip install -e ${app} || echo "couldn't install ${app}"
+done
+
+exec ../../docker-entrypoint.sh "${@}"

--- a/apps_dev/dev-entrypoint.sh
+++ b/apps_dev/dev-entrypoint.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-echo $(pwd)
-for app in $(ls -d ../../apps_dev/*/); do
-    pip install -e ${app} || echo "couldn't install ${app}"
+cd ../..
+
+for app in $(ls -d apps_dev/*/); do
+    pip install -e ${app} || echo "$(basename ${0}): couldn't install ${app}"
 done
 
+cd src/netdash
 exec ../../docker-entrypoint.sh "${@}"

--- a/apps_dev/dev-entrypoint.sh
+++ b/apps_dev/dev-entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 cd ../..
 
 for app in $(ls -d apps_dev/*/); do
-    pip install -e ${app} || echo "$(basename ${0}): couldn't install ${app}"
+    pip3 install -e ${app} || echo "$(basename ${0}): couldn't install ${app}"
 done
 
 cd src/netdash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,12 @@ services:
       - database
       - netbox
     environment:
-      - NETDASH_DEBUG=True
-      - NETDASH_SECRET_KEY=12345
-      - NETDASH_DEVICE_MODULE=netdash_device_netbox_api
-      - DATABASE_URL=postgres://netdash@database/netdash
       - NETDASH_MODULES=${NETDASH_MODULES}
       - NETBOX_API_URL=${NETBOX_API_URL-http://netbox:8000/api}
       - NETBOX_API_TOKEN=${NETBOX_API_TOKEN-0123456789abcdef0123456789abcdef01234567}
+    env_file:
+      - .defaults.env
+      - .user-settings.env
     ports:
       - 8888:8000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - 8888:8000
     volumes:
       - .:/usr/src/app:ro
+    entrypoint: ../../apps_dev/dev-entrypoint.sh
+    command: "python manage.py runserver 0.0.0.0:8000"
 
   database:
     image: postgres:10.4-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - database
       - netbox
     environment:
-      - NETDASH_MODULES=${NETDASH_MODULES}
       - NETBOX_API_URL=${NETBOX_API_URL-http://netbox:8000/api}
       - NETBOX_API_TOKEN=${NETBOX_API_TOKEN-0123456789abcdef0123456789abcdef01234567}
     env_file:


### PR DESCRIPTION
Closes #11 

Two files are added: 
`.defaults.env` - Has default settings for netdash environment
`.user-settings.env` - User can override default settings, add variables for use with their own apps.

This way the `docker-compose.yml` doesn't have to be modified by the user.