### PR TITLE
Install apps in NETDASH_MODULES only

### DIFF
--- a/.defaults.env
+++ b/.defaults.env
@@ -4,4 +4,4 @@
 NETDASH_DEBUG=True
 NETDASH_SECRET_KEY=12345
 DATABASE_URL=postgres://netdash@database/netdash
-NETDASH_MODULES=
+NETDASH_MODULES=example_devices_dummy, example_devices_netbox_api, example_devices_snmp

--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -5,7 +5,13 @@ set -e
 cd ../..
 
 for app in $(ls -d apps_dev/*/); do
-    pip3 install -e ${app} || echo "$(basename ${0}): couldn't install ${app}"
+    app_name=$(grep "name=" ${app}/setup.py | sed -E -e "s/name=|[\'\,]//g" -e "s/[\-]/\_/g")
+
+    if `grep "NETDASH_MODULES" .user-settings.env | grep -q  ${app_name}`
+    then
+        pip3 install -e ${app} || echo "$(basename ${0}): couldn't install ${app}"
+    fi
+
 done
 
 cd src/netdash

--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -6,8 +6,9 @@ cd ../..
 
 for app in $(ls -d apps_dev/*/); do
     app_name=$(grep "name=" ${app}/setup.py | sed -E -e "s/name=|[\'\,]//g" -e "s/[\-]/\_/g")
+    modules=$(grep "NETDASH_MODULES=" .user-settings.env || grep "NETDASH_MODULES=" .defaults.env)
 
-    if `grep "NETDASH_MODULES" .user-settings.env | grep -q  ${app_name}`
+    if [[ $(echo "${modules}" | grep ${app_name}) ]]
     then
         pip3 install -e ${app} || echo "$(basename ${0}): couldn't install ${app}"
     fi


### PR DESCRIPTION
This way the `docker-entrypoint-dev.sh` will only install those modules that are included in `NETDASH_MODULES`
This will increase the speed at which the container is spun up and reduce disk space.