### PR TITLE
Installs git in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 
 RUN apt-get -y update
-RUN apt-get -y git
+RUN apt-get -y install git
 
 RUN pip install psycopg2-binary
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.7-slim
 
+RUN apt-get -y update
+RUN apt-get -y git
+
 RUN pip install psycopg2-binary
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 


### PR DESCRIPTION
The change to use a slim python image for ND docker container caused git to not install by default. Added two lines to make that work. This was packages installed through git will not face problems.