### PR TITLE
Build & Push to Docker via circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,74 @@
 version: 2
+
+aliases:
+  - &fix_permissions
+      run:
+        name: Fix Permissions
+        command: |
+          sudo chown -R circleci:circleci /usr/local/bin
+          sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+  - &restore_dependencies_cache
+      restore_cache:
+        key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+  - &install_dependencies
+      run:
+        name: Install Dependencies
+        command: |
+          sudo pip install pipenv bandit flake8
+          pipenv install
+  - &update_dependencies_cache
+      save_cache:
+        key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+        paths:
+          - '.venv'
+          - '/usr/local/bin'
+          - '/usr/local/lib/python3.7/site-packages'
+  - python_job_base: &python_job_base
+      docker:
+        - image: circleci/python:3.7.3
+          environment:
+            PIPENV_VENV_IN_PROJECT: "true"
+
 jobs:
-  build:
-    docker:
-      - image: circleci/python:3.7.3
-        environment:
-          PIPENV_VENV_IN_PROJECT: true
+  check:
+    <<: *python_job_base
     steps:
       - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
-      - restore_cache:
-          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-      - run: sudo pip install pipenv bandit flake8
-      - run: pipenv install
-      - save_cache:
-          key: deps10-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - '.venv'
-            - '/usr/local/bin'
-            - '/usr/local/lib/python3.7/site-packages'
+      - *fix_permissions
+      - *restore_dependencies_cache
+      - *install_dependencies
+      - *update_dependencies_cache
       - run: bandit -r src/netdash -x src/netdash/netdash/\*example\*.py
       - run: flake8 src/netdash
       - run: cp src/netdash/netdash/settings_example.py src/netdash/netdash/settings.py
       - run: pipenv run python src/netdash/manage.py test
+  # publish:
+  #   environment:
+  #     IMAGE_NAME: src/netdash/netdash/\*example\*.py
+  #   docker:
+  #     - image: circleci/buildpack-deps:stretch
+  #   steps:
+  #     - checkout
+  #     - setup_remote_docker
+  #     - run: docker build -t $IMAGE_NAME:latest .
+  #     - run: |
+  #         echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+  #         docker push $IMAGE_NAME:latest
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - check
+
+#     jobs:
+#       - check:
+#           filters:
+#             tags:
+#               only: /.*/
+#       - publish-tag
+#           requires:
+#             - check
+#           filters:
+#             tags:
+#               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 aliases:
   - &fix_permissions
@@ -28,6 +28,10 @@ aliases:
         - image: circleci/python:3.7.3
           environment:
             PIPENV_VENV_IN_PROJECT: "true"
+  - &run_on_tags
+    filters:
+      tags:
+        only: /.*/
 
 jobs:
   bandit:
@@ -58,35 +62,40 @@ jobs:
       - *update_dependencies_cache
       - run: cp src/netdash/netdash/settings_example.py src/netdash/netdash/settings.py
       - run: pipenv run python src/netdash/manage.py test
-  # publish:
-  #   environment:
-  #     IMAGE_NAME: src/netdash/netdash/\*example\*.py
-  #   docker:
-  #     - image: circleci/buildpack-deps:stretch
-  #   steps:
-  #     - checkout
-  #     - setup_remote_docker
-  #     - run: docker build -t $IMAGE_NAME:latest .
-  #     - run: |
-  #         echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-  #         docker push $IMAGE_NAME:latest
+  publish-tag:
+    environment:
+      IMAGE_NAME: netdash/netdash
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - run: 
+          name: Abort if no tag
+          command: |
+            if [ -z "$CIRCLE_TAG" ]; then
+              echo Aborting
+              circleci-agent step halt
+            fi
+      - checkout
+      - setup_remote_docker
+      - run: |
+          docker build -t $IMAGE_NAME:$CIRCLE_TAG .
+      - run: |
+          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker push $IMAGE_NAME:$CIRCLE_TAG
 
 workflows:
-  version: 2
-  commit:
+  workflow:
     jobs:
-      - bandit
-      - flake8
-      - test
-
-#     jobs:
-#       - check:
-#           filters:
-#             tags:
-#               only: /.*/
-#       - publish-tag
-#           requires:
-#             - check
-#           filters:
-#             tags:
-#               only: /.*/
+      - bandit:
+          <<: *run_on_tags
+      - flake8:
+          <<: *run_on_tags
+      - test:
+          <<: *run_on_tags
+      - publish-tag:
+          <<: *run_on_tags
+          requires:
+            - bandit
+            - flake8
+            - test
+          context: docker-hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ aliases:
             PIPENV_VENV_IN_PROJECT: "true"
 
 jobs:
-  check:
+  bandit:
     <<: *python_job_base
     steps:
       - checkout
@@ -39,7 +39,23 @@ jobs:
       - *install_dependencies
       - *update_dependencies_cache
       - run: bandit -r src/netdash -x src/netdash/netdash/\*example\*.py
+  flake8:
+    <<: *python_job_base
+    steps:
+      - checkout
+      - *fix_permissions
+      - *restore_dependencies_cache
+      - *install_dependencies
+      - *update_dependencies_cache
       - run: flake8 src/netdash
+  test:
+    <<: *python_job_base
+    steps:
+      - checkout
+      - *fix_permissions
+      - *restore_dependencies_cache
+      - *install_dependencies
+      - *update_dependencies_cache
       - run: cp src/netdash/netdash/settings_example.py src/netdash/netdash/settings.py
       - run: pipenv run python src/netdash/manage.py test
   # publish:
@@ -59,7 +75,9 @@ workflows:
   version: 2
   commit:
     jobs:
-      - check
+      - bandit
+      - flake8
+      - test
 
 #     jobs:
 #       - check:


### PR DESCRIPTION
Expands upon @ksofa2's initial circleci configuration.

Right now, any *tag* will trigger a Docker build & push with the same tag.

Because there was no way filter build steps to tags but not branches ([incredibly](https://discuss.circleci.com/t/not-running-job-based-on-filter-tags-only-and-filter-branch-ignore/23379)), the build & publish step will conditionally exit if it's not a tag.