### PR TITLE
VS Code Quickstart

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,15 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details or
+// https://aka.ms/vscode-dev-containers/definitions for sample configurations.
+{
+	"name": "NetDash",
+	"dockerComposeFile": [
+		"docker-compose.yml",
+		"docker-compose-vscode.yml"
+	],
+	"service": "app",
+	"workspaceFolder": "/usr/src/app",
+	"extensions": [
+		"donjayamanne.python-extension-pack"
+	],
+	"postCreateCommand": "pipenv install --system -d; cd src/netdash; ../../docker-entrypoint-dev.sh"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/netdash/manage.py",
+            "console": "integratedTerminal",
+            "args": [
+                "runserver",
+                "0.0.0.0:8000",
+                "--noreload",
+            ],
+            "django": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "python.pythonPath": "/usr/local/bin/python",
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.linting.flake8Args": [
+    "src/netdash"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,12 @@
   "python.linting.enabled": true,
   "python.linting.flake8Args": [
     "src/netdash"
+  ],
+  "python.autoComplete.extraPaths": [
+    "./src/netdash",
+    "./apps_dev/example_devices_dummy",
+    "./apps_dev/example_devices_netbox_api",
+    "./apps_dev/example_devices_snmp",
+    "./apps_dev/example_hostlookup_dummy"
   ]
 }

--- a/docker-compose-vscode.yml
+++ b/docker-compose-vscode.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+services:
+  app:
+    entrypoint: ""
+    command: /bin/sh -c "while sleep 1000; do :; done"


### PR DESCRIPTION
This PR contains configuration for a complete VS Code dev env using VS Code Remote Containers. With these files, all you need to get started is to install the Remote Containers extension, start VS Code in the directory where NetDash is cloned, and accept the prompt to Reopen in Container. Linting, intellisense, and debugging are all set up and integrated with the IDE.

We don't necessarily need to merge this, but I wanted to push it here for others to reference. Maybe it could be worked into the docs at some point.