### PR TITLE
Feedback mailto link (optionally enabled)

### DIFF
--- a/netdash/netdash/settings_env.py
+++ b/netdash/netdash/settings_env.py
@@ -113,6 +113,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'netdash_ui.context_processors.feedback',
             ],
         },
     },
@@ -182,6 +183,10 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+
+FEEDBACK_EMAIL = os.getenv('NETDASH_FEEDBACK_EMAIL', None)
+
 
 _saml2_entity_id = os.getenv('SAML2_ENTITY_ID', None)
 _saml2_sp_name = os.getenv('SAML2_SP_NAME', None)

--- a/netdash/netdash/settings_example.py
+++ b/netdash/netdash/settings_example.py
@@ -80,6 +80,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'netdash_ui.context_processors.feedback',
             ],
         },
     },

--- a/netdash/netdash/settings_example_compose.py
+++ b/netdash/netdash/settings_example_compose.py
@@ -83,6 +83,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'netdash_ui.context_processors.feedback',
             ],
         },
     },

--- a/netdash/netdash_ui/context_processors.py
+++ b/netdash/netdash_ui/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
 
+
 def feedback(request):
     return {'FEEDBACK_EMAIL': settings.FEEDBACK_EMAIL}

--- a/netdash/netdash_ui/context_processors.py
+++ b/netdash/netdash_ui/context_processors.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+def feedback(request):
+    return {'FEEDBACK_EMAIL': settings.FEEDBACK_EMAIL}

--- a/netdash/netdash_ui/templates/base.html
+++ b/netdash/netdash_ui/templates/base.html
@@ -39,13 +39,24 @@
         </li>
         {% endif %}
       </ul>
-      <div class="my-2 my-lg-0">
+      <div class="navbar-nav ml-auto">
         {% if request.user.is_authenticated %}
-        <em class="text-white">{{ request.user.username }}</em>
-        <a href="{% url 'logout' %}" class="text-light small">logout</a>
+        {% if FEEDBACK_EMAIL %}
+        <li class="nav-item">
+          <a class="nav-link active" target="_blank" href="mailto:{{ FEEDBACK_EMAIL }}">Feedback</a>
+        </li>
+        {% endif %}
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="userMenu" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            {{ request.user.username }}
+          </a>
+          <div class="dropdown-menu" aria-labelledby="userMenu">
+            <a href="{% url 'logout' %}" class="dropdown-item">Logout</a>
+          </div>
+        </li>
         {% else %}
         <!-- TODO replace with properly derived login url -->
-        <a href="/admin/login?next={{ request.get_full_path }}" class="text-light small">login</a>
+        <a href="/admin/login?next={{ request.get_full_path }}" class="nav-link">login</a>
         {% endif %}
       </div>
     </div>

--- a/netdash/netdash_ui/templates/base.html
+++ b/netdash/netdash_ui/templates/base.html
@@ -43,7 +43,7 @@
         {% if request.user.is_authenticated %}
         {% if FEEDBACK_EMAIL %}
         <li class="nav-item">
-          <a class="nav-link active" target="_blank" href="mailto:{{ FEEDBACK_EMAIL }}">Feedback</a>
+          <a class="nav-link active" target="_blank" href="mailto:{{ FEEDBACK_EMAIL }}?subject=NetDash Feedback&body=Let us know what you think! Details and screenshots are helpful and appreciated.%0D%0A%0D%0AURL: {{ request.build_absolute_uri }}%0D%0ATechnical Details: {{ request.headers }}">Feedback</a>
         </li>
         {% endif %}
         <li class="nav-item dropdown">

--- a/netdash/netdash_ui/templates/base.html
+++ b/netdash/netdash_ui/templates/base.html
@@ -43,7 +43,12 @@
         {% if request.user.is_authenticated %}
         {% if FEEDBACK_EMAIL %}
         <li class="nav-item">
-          <a class="nav-link active" target="_blank" href="mailto:{{ FEEDBACK_EMAIL }}?subject=NetDash Feedback&body=Let us know what you think! Details and screenshots are helpful and appreciated.%0D%0A%0D%0AURL: {{ request.build_absolute_uri }}%0D%0ATechnical Details: {{ request.headers }}">Feedback</a>
+          <a 
+            class="nav-link active" 
+            target="_blank" 
+            href="mailto:{{ FEEDBACK_EMAIL }}?subject=NetDash Feedback&body=Let us know what you think! Details and screenshots are helpful and appreciated.%0D%0A%0D%0AURL: {{ request.build_absolute_uri }}%0D%0ATechnical Details: {{ request.headers }}">
+            Feedback
+          </a>
         </li>
         {% endif %}
         <li class="nav-item dropdown">
@@ -56,7 +61,7 @@
         </li>
         {% else %}
         <!-- TODO replace with properly derived login url -->
-        <a href="/admin/login?next={{ request.get_full_path }}" class="nav-link">login</a>
+        <a href="/admin/login?next={{ request.get_full_path }}" class="nav-link">Login</a>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
If FEEDBACK_EMAIL is defined in settings.py, a feedback mailto link will be (globally) generated in the navbar. This PR also pretties up the navbar a bit, putting the logout button in a dropdown.

I made a first attempt with a Django feedback app, but it was not well enough supported. A more robust feedback widget would require Ajax, which is more complexity than I would want for this feature.