### PR TITLE
Default datatable rows for hostlookup set to 100

### DIFF
--- a/netdash/hostlookup_abstract/templates/hostlookup/hostlookupresult_list.html
+++ b/netdash/hostlookup_abstract/templates/hostlookup/hostlookupresult_list.html
@@ -22,7 +22,7 @@ $('.datatable').DataTable({
 
 {% block results %}
 {% if results %}
-<table class='table datatable table-striped table-bordered'>
+<table class='table datatable table-striped table-bordered' data-page-length='100'>
   <thead>
     <tr>
       <th>MAC Address</th>

--- a/netdash/hostlookup_bluecat/templates/hostlookup_bluecat/hostlookupresult_list.html
+++ b/netdash/hostlookup_bluecat/templates/hostlookup_bluecat/hostlookupresult_list.html
@@ -26,7 +26,7 @@ $('.datatable').DataTable({
 
 {% block results %}
 {% if results %}
-<table class='table datatable table-striped table-bordered'>
+<table class='table datatable table-striped table-bordered' data-page-length='100'>
   <thead>
     <tr>
       <th>MAC Address</th>


### PR DESCRIPTION
Closes #54 

There are certain bugs with the template system with `hostlookup_abstract` and `hostlookup_combined`. Otherwise, on testing with `hostlookup_bluecat` the changes work as required.
